### PR TITLE
Remove `{% load url from future %}`

### DIFF
--- a/adminsortable/templates/adminsortable/change_form.html
+++ b/adminsortable/templates/adminsortable/change_form.html
@@ -1,6 +1,5 @@
 {% extends change_form_template_extends %}
 {% load i18n admin_modify %}
-{% load url from future %}
 {% load static from staticfiles %}
 
 {% block extrahead %}


### PR DESCRIPTION
`{% load url from future %}` can be removed from templates since Django 1.5 and it will be removed from Django in 1.9

https://docs.djangoproject.com/en/1.8/releases/1.5/#django-1-5-release-notes
https://docs.djangoproject.com/en/dev/releases/1.7/#loading-ssi-and-url-template-tags-from-future-library
